### PR TITLE
chore: add commented .env.example for all MCP env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ MONERO_RPC_PASS=
 # -----------------------------------------------------------------------------
 
 # Monero network: mainnet, stagenet, or testnet (must match wallet-rpc and daemon)
-MONERO_NETWORK=mainnet
+MONERO_NETWORK=testnet
 
 # -----------------------------------------------------------------------------
 # Transfers (sending XMR)


### PR DESCRIPTION
- Document MONERO_RPC_HOST, MONERO_RPC_PORT, MONERO_RPC_USER, MONERO_RPC_PASS (wallet RPC connection; no single URL var in codebase)
- Document MONERO_NETWORK, MONERO_ALLOW_TRANSFERS, transfer limits, MONERO_ALLOWED_ADDRESSES, MONERO_REQUIRE_CONFIRMATION, MONERO_AUDIT_LOG_FILE
- Comments explain each variable; no real secrets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds a commented `.env.example` that documents all MONERO_* environment variables used by the Monero MCP server. The file documents RPC connection (MONERO_RPC_HOST, MONERO_RPC_PORT, MONERO_RPC_USER, MONERO_RPC_PASS), MONERO_NETWORK, MONERO_ALLOW_TRANSFERS, transfer limits, MONERO_ALLOWED_ADDRESSES, MONERO_REQUIRE_CONFIRMATION, MONERO_AUDIT_LOG_FILE, and includes explanatory comments and the header warning not to commit real secrets.

Only observable change vs. previous examples: the MONERO_NETWORK stagenet default line was removed and the file now sets MONERO_NETWORK=testnet. No other variables, defaults, or runtime logic were changed.

Security impact: LOW RISK — HIGH VALUE

- Secure-by-default settings are documented (read-only by default, confirmation required, empty allowlist, 60s cooldown, audit log path). These match existing code and spec (src/config.ts, monero-mcp-spec.md, SECURITY.md).
- Prompt-injection defenses and operational mitigations are documented: address allowlist, two-step confirmation tokens, cooldown/daily limits, JSONL audit logging, and input validation.
- No real secrets are included (MONERO_RPC_PASS left empty). No code that handles secrets was modified.

Findings / recommendations
- The only notable documentation change is MONERO_NETWORK default set to testnet in .env.example (monero-mcp-spec.md still contains a stagenet example line elsewhere). Confirm operators pick the correct network for their deployment.
- Reiterate (security-critical) danger: do not run with an empty MONERO_ALLOWED_ADDRESSES together with MONERO_REQUIRE_CONFIRMATION=false — that configuration allows unauthorized automated transfers. Consider adding an explicit comment in `.env.example` warning against disabling confirmation when allowlist is empty.

CRITICAL changes: none (no code changes that alter transfer logic, token generation, rate limits, allowlist checks, or secret handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->